### PR TITLE
Add support for getArrayUnsignedBytes()

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Method                            | Type                    | Values
 `$buffer->getFloat()`             | float (4 bytes)         | single-precision 32-bit IEEE 754 floating point number
 `$buffer->getDouble()`            | double (5 bytes)        | double-precision 64-bit IEEE 754 floating point number
 `$buffer->getArrayBytes($length)` | byte[]                  | `array`
+`$buffer->getArrayUnsignedBytes($length)` | unsigned byte[]         | `array`
 `$buffer->getString($length)`     | string (length bytes)   | `string`
 `$buffer->getUTF()`               | string                  | `string`
 `$buffer->getUTF16($length)`      | string (length * 2)     | `string`

--- a/src/Nelexa/Buffer/Buffer.php
+++ b/src/Nelexa/Buffer/Buffer.php
@@ -390,6 +390,23 @@ abstract class Buffer
     }
 
     /**
+     * Reads $length unsigned bytes from an input stream.
+     *
+     * @param $length int
+     * @return int[]
+     * @throws BufferException
+     */
+    public function getArrayUnsignedBytes($length)
+    {
+        if ($length > 0) {
+            return array_values(
+                unpack('C*', $this->get($length))
+            );
+        }
+        return [];
+    }
+
+    /**
      * Reads in a string that has been encoded using
      * a modified UTF-8 format.
      *

--- a/tests/Nelexa/Buffer/BufferTestCase.php
+++ b/tests/Nelexa/Buffer/BufferTestCase.php
@@ -152,6 +152,9 @@ abstract class BufferTestCase extends \PHPUnit_Framework_TestCase
             $arrayBytes = [0x01, 0x02, 0x03, 0x4, Cast::toByte(Cast::INTEGER_MAX_VALUE)];
             $this->buffer->insertArrayBytes($arrayBytes);
 
+            $arrayUnsignedBytes = [0x01, 0x22, 0x7f, 0xee, Cast::toUnsignedByte(Cast::INTEGER_MAX_VALUE)];
+            $this->buffer->insertArrayBytes($arrayUnsignedBytes);
+
             $string = 'String... Строка... 串...
  😀 😬 😁 😂 😃 😄 😅 😆 😇 😉 😊 😊 🙂 🙃 ☺️ 😋 😌 😍 😘 
  🇦🇫 🇦🇽 🇦🇱 🇩🇿 🇦🇸 🇦🇩 🇦🇴 🇦🇮 🇦🇶 🇦🇬 🇦🇷 🇦🇲 🇦🇼 🇦🇺 🇦🇹
@@ -261,17 +264,20 @@ abstract class BufferTestCase extends \PHPUnit_Framework_TestCase
             $this->assertEquals($this->buffer->getArrayBytes(5), $arrayBytes);
             $this->assertEquals($this->buffer->position(), 76);
 
+            $this->assertEquals($this->buffer->getArrayUnsignedBytes(5), $arrayUnsignedBytes);
+            $this->assertEquals($this->buffer->position(), 81);
+
             $this->assertEquals($this->buffer->getString($lengthString), $string);
-            $this->assertEquals($this->buffer->position(), 76 + $lengthString);
+            $this->assertEquals($this->buffer->position(), 81 + $lengthString);
 
             $this->assertEquals($this->buffer->getUTF(), $string);
-            $this->assertEquals($this->buffer->position(), 78 + $lengthString * 2);
+            $this->assertEquals($this->buffer->position(), 83 + $lengthString * 2);
 
             $this->assertEquals($this->buffer->getUTF16($lengthString), $string);
-            $this->assertEquals($this->buffer->position(), 78 + $lengthString * 4);
+            $this->assertEquals($this->buffer->position(), 83 + $lengthString * 4);
 
             $this->assertEquals($this->buffer->getString($lengthString), $otherBuffer->toString());
-            $this->assertEquals($this->buffer->position(), 78 + $lengthString * 5);
+            $this->assertEquals($this->buffer->position(), 83 + $lengthString * 5);
         }
     }
 
@@ -554,6 +560,9 @@ abstract class BufferTestCase extends \PHPUnit_Framework_TestCase
 
         $buffer->rewind();
         $this->assertEquals($buffer->getArrayBytes(8), [64, 41, 85, 54, 37, 109, -74, 71]);
+
+        $buffer->rewind();
+        $this->assertEquals($buffer->getArrayUnsignedBytes(8), [64, 41, 85, 54, 37, 109, 182, 71]);
     }
 
     /**
@@ -579,5 +588,8 @@ abstract class BufferTestCase extends \PHPUnit_Framework_TestCase
 
         $buffer->rewind();
         $this->assertEquals($buffer->getArrayBytes(4), [65, 74, -87, -79]);
+
+        $buffer->rewind();
+        $this->assertEquals($buffer->getArrayUnsignedBytes(4), [65, 74, 169, 177]);
     }
 }


### PR DESCRIPTION
A simple addition to this library to allow for reading multiple unsigned bytes into an array.  Unit tests added and passing.

Without this function it was required to do this:

```
$bytes = $this->buffer->getArrayBytes(5);
$unsigned_bytes = array_map(fn($v) => $v & 0xff, $bytes);
```

with this patch, you can now simply do this:
```
$unsigned_bytes = $this->buffer->getArrayUnsignedBytes(5);
```

